### PR TITLE
Fix type hints

### DIFF
--- a/hyperlight/convert.py
+++ b/hyperlight/convert.py
@@ -85,8 +85,8 @@ def hypernetize_single(
 
 def hypernetize(
     model: nn.Module,
-    modules: Optional[List[nn.Module]] = None,
-    parameters: Optional[List[nn.Parameter]] = None,
+    modules: Optional[Union[List[nn.Module], Dict[str, nn.Module]]] = None,
+    parameters: Optional[Union[List[nn.Parameter], Dict[str, nn.Parameter]]] = None,
     return_values: bool = False,
     inplace: bool = True,
 ):


### PR DESCRIPTION
This example in the readme results in failed type checks:

```py
modules = hl.find_modules_of_type(mainnet, [nn.Conv2d])
self.mainnet = hl.hypernetize(mainnet, modules=modules)
```